### PR TITLE
fix: Force installation on internal memory.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="net.typeblog.shelter">
+    package="net.typeblog.shelter"
+    android:installLocation="internalOnly" >
 
     <uses-feature android:name="android.software.device_admin" android:required="true"/>
     <uses-feature android:name="android.software.managed_users" android:required="true"/>


### PR DESCRIPTION
Shelter will only install on internal memory since device managers
can't work from external memory.